### PR TITLE
Add repeating spend functionality

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -3,8 +3,8 @@
     package="com.notriddle.budget"
     android:hardwareAccelerated="true"
     android:installLocation="auto"
-    android:versionCode="43"
-    android:versionName="4.3" >
+    android:versionCode="44"
+    android:versionName="4.4" >
 
     <uses-sdk
         android:minSdkVersion="15"

--- a/res/layout-land/spendfragment.xml
+++ b/res/layout-land/spendfragment.xml
@@ -33,6 +33,24 @@
         android:layout_height="wrap_content"
     />
 
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                  android:layout_width="wrap_content"
+                  android:layout_height="wrap_content"
+                  android:layout_weight="2"
+                  android:layout_gravity="center_vertical"
+                  android:orientation="horizontal">
+	    <CheckBox android:id="@+id/repeat"
+	              android:text="@string/repeat_checkBox"
+	              android:layout_width="fill_parent"
+	              android:layout_height="wrap_content"/>
+	    <Spinner android:id="@+id/frequency"
+	             android:layout_width="fill_parent"
+	             android:layout_height="wrap_content"
+	             android:enabled="false"
+	             android:textColor="#000"
+	             />
+    </LinearLayout>
+
     <CheckBox android:id="@+id/delayed"
               android:text="@string/delayed_checkBox"
               android:layout_width="fill_parent"

--- a/res/layout/spendfragment.xml
+++ b/res/layout/spendfragment.xml
@@ -26,6 +26,24 @@
     android:layout_height="wrap_content"
 />
 
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                  android:layout_width="wrap_content"
+                  android:layout_height="wrap_content"
+                  android:layout_weight="2"
+                  android:layout_gravity="center_vertical"
+                  android:orientation="horizontal">
+	    <CheckBox android:id="@+id/repeat"
+	              android:text="@string/repeat_checkBox"
+	              android:layout_width="fill_parent"
+	              android:layout_height="wrap_content"/>
+	    <Spinner android:id="@+id/frequency"
+	             android:layout_width="fill_parent"
+	             android:layout_height="wrap_content"
+	             android:enabled="false"
+	             android:textColor="#000"
+	             />
+    </LinearLayout>
+
 <CheckBox android:id="@+id/delayed"
           android:text="@string/delayed_checkBox"
           android:layout_width="fill_parent"

--- a/res/layout/spinner_item.xml
+++ b/res/layout/spinner_item.xml
@@ -1,0 +1,9 @@
+<TextView  
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/spinner_item"
+    android:layout_width="match_parent" 
+    android:layout_height="wrap_content"
+    android:gravity="left"  
+    android:textColor="#000"         
+    android:padding="5dip"
+    />

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -61,6 +61,15 @@
     <string name="import_settings">Import</string>
     <string name="import_settings_summary">Restore financial data</string>
     <string name="delayed_checkBox">Delayed</string>
+    <string name="repeat_checkBox">Repeat</string>
+    <string-array name="frequency_array">
+	    <item>Daily</item>
+	    <item>Weekly</item>
+	    <item>Fortnightly</item>
+	    <item>Monthly</item>
+	    <item>Quarterly</item>
+	    <item>Yearly</item>
+    </string-array>
     <string name="about_menuItem">About</string>
     <string name="about_name">About Budget with Envelopes</string>
     <string name="donate_button">Donate to Michael</string>

--- a/src/com/notriddle/budget/EditTransactionFragment.java
+++ b/src/com/notriddle/budget/EditTransactionFragment.java
@@ -81,6 +81,8 @@ public class EditTransactionFragment extends OkFragment
         mDescription = (EditText) retVal.findViewById(R.id.description);
         retVal.findViewById(R.id.delayed).setVisibility(View.GONE);
         retVal.findViewById(R.id.delay).setVisibility(View.GONE);
+        retVal.findViewById(R.id.repeat).setVisibility(View.GONE);
+        retVal.findViewById(R.id.frequency).setVisibility(View.GONE);
         return retVal;
     }
 

--- a/src/com/notriddle/budget/EnvelopesOpenHelper.java
+++ b/src/com/notriddle/budget/EnvelopesOpenHelper.java
@@ -24,10 +24,11 @@ import android.database.Cursor;
 import android.database.sqlite.*;
 import android.net.Uri;
 import android.util.SparseArray;
+import java.util.GregorianCalendar;
 
 public class EnvelopesOpenHelper extends SQLiteOpenHelper {
     static final String DB_NAME = "envelopes.db";
-    static final int DB_VERSION = 6;
+    static final int DB_VERSION = 7;
     public static final Uri URI = Uri.parse("sqlite://com.notriddle.budget/envelopes");
 
     Context mCntx;
@@ -56,7 +57,7 @@ public class EnvelopesOpenHelper extends SQLiteOpenHelper {
         values.put("lastPaycheckCents", 0);
         values.put("color", 0);
         db.insert("envelopes", null, values);
-        db.execSQL("CREATE TABLE 'log' ( '_id' INTEGER PRIMARY KEY, 'envelope' INTEGER, 'time' TIMESTAMP, 'description' TEXT, 'cents' INTEGER )");
+        db.execSQL("CREATE TABLE 'log' ( '_id' INTEGER PRIMARY KEY, 'envelope' INTEGER, 'time' TIMESTAMP, 'description' TEXT, 'cents' INTEGER, 'repeat' STRING )");
     }
 
     @Override public void onUpgrade(SQLiteDatabase db, int oldVer, int newVer) {
@@ -74,10 +75,13 @@ public class EnvelopesOpenHelper extends SQLiteOpenHelper {
         } else if (oldVer == 5) {
             db.execSQL("UPDATE envelopes SET color = 0 WHERE color = ?", new String[] {Integer.toString(0xFFEEEEEE)});
         }
+        if (oldVer < 7){
+            db.execSQL("ALTER TABLE 'log' ADD COLUMN 'repeat' STRING");
+        } 
     }
 
     public static void deposite(SQLiteDatabase db, int envelope, long cents,
-                                String description) {
+                                String description, String frequency) {
         if (cents != 0) {
             String envelopeString = Integer.toString(envelope);
             String[] envelopeStringArray = new String[] {envelopeString};
@@ -96,16 +100,17 @@ public class EnvelopesOpenHelper extends SQLiteOpenHelper {
             values.put("time", System.currentTimeMillis());
             values.put("description", description);
             values.put("cents", cents);
+            values.put("repeat", frequency);
             db.insert("log", null, values);
         }
     }
     public static void deposite(Context cntx, int envelope, long cents,
-                                String description) {
+                                String description, String frequency) {
         SQLiteDatabase db = (new EnvelopesOpenHelper(cntx))
                             .getWritableDatabase();
         db.beginTransaction();
         try {
-            deposite(db, envelope, cents, description);
+	        deposite(db, envelope, cents, description, frequency);
             db.setTransactionSuccessful();
             cntx.getContentResolver().notifyChange(URI, null);
         } finally {
@@ -115,7 +120,41 @@ public class EnvelopesOpenHelper extends SQLiteOpenHelper {
     }
     public static void playLog(SQLiteDatabase db) {
         long currentTime = System.currentTimeMillis();
-        db.execSQL("UPDATE envelopes SET cents = (SELECT SUM(log.cents) FROM log WHERE log.envelope = envelopes._id AND log.time < ? GROUP BY log.envelope), projectedCents = (SELECT SUM(log.cents) FROM log WHERE log.envelope = envelopes._id GROUP BY log.envelope)", new String[] {Long.toString(currentTime)});
+        /* First insert repeated transaction up to now */
+        Cursor csr
+	        = db.rawQuery("SELECT envelope, MAX(time) AS last, cents, description, repeat FROM log WHERE repeat IS NOT NULL AND time < ? GROUP BY envelope, cents, description, repeat", new String [] {Long.toString(currentTime)});
+        if (csr.moveToFirst()) {
+	        do {
+		        long last = csr.getLong(csr.getColumnIndexOrThrow("last"));
+		        int envelope = csr.getInt(csr.getColumnIndexOrThrow("envelope"));
+		        long cents = csr.getLong(csr.getColumnIndexOrThrow("cents"));
+		        String description = csr.getString(csr.getColumnIndexOrThrow("description"));
+		        String repeat = csr.getString(csr.getColumnIndexOrThrow("repeat"));
+		        if (repeat == null) continue;
+		        
+		        GregorianCalendar cal = new GregorianCalendar();
+		        cal.setTimeInMillis(last);
+		        while (cal.getTimeInMillis() < currentTime) {
+			        if ( repeat.toLowerCase().equals("monthly") ){
+				        cal.add((GregorianCalendar.MONTH), 1);
+			        } else if ( repeat.toLowerCase().equals("daily") ){
+				        cal.add((GregorianCalendar.DAY_OF_MONTH), 1);
+			        } else if ( repeat.toLowerCase().equals("weekly") ){
+				        cal.add((GregorianCalendar.WEEK_OF_YEAR), 1);
+			        } else if ( repeat.toLowerCase().equals("yearly") ){
+				        cal.add((GregorianCalendar.YEAR), 1);
+			        } else if ( repeat.toLowerCase().equals("fortnightly") ){
+				        cal.add((GregorianCalendar.WEEK_OF_YEAR), 2);
+			        } else if ( repeat.toLowerCase().equals("quarterly") ){
+				        cal.add((GregorianCalendar.MONTH), 3);
+			        }
+			        /* This will always deposit one payment in advance - by design */
+			        depositeDelayed(db, envelope, cents, description, repeat, cal.getTimeInMillis());
+			        db.execSQL("UPDATE log SET repeat = NULL WHERE time < ?", new String [] {Long.toString(currentTime)});	        
+		        } 
+	        } while(csr.moveToNext());
+        }
+        db.execSQL("UPDATE envelopes SET cents = (SELECT SUM(log.cents) FROM log WHERE log.envelope = envelopes._id AND log.time < ? GROUP BY log.envelope), projectedCents = (SELECT SUM(log.cents) FROM log WHERE log.envelope = envelopes._id GROUP BY log.envelope)", new String [] {Long.toString(currentTime)});
     }
     public static void playLog(Context cntx) {
         SQLiteDatabase db = (new EnvelopesOpenHelper(cntx))
@@ -132,7 +171,7 @@ public class EnvelopesOpenHelper extends SQLiteOpenHelper {
     }
     public static void depositeDelayed(SQLiteDatabase db, int envelope,
                                        long cents, String description,
-                                       long delayUntil) {
+                                       String repeat, long delayUntil) {
         if (cents != 0) {
             String envelopeString = Integer.toString(envelope);
             String[] envelopeStringArray = new String[] {envelopeString};
@@ -152,16 +191,17 @@ public class EnvelopesOpenHelper extends SQLiteOpenHelper {
             lValues.put("time", delayUntil);
             lValues.put("description", description);
             lValues.put("cents", cents);
+            lValues.put("repeat", repeat);
             db.insert("log", null, lValues);
         }
     }
     public static void depositeDelayed(Context cntx, int envelope, long cents,
-                                       String description, long delayUntil) {
+                                       String description, String repeat, long delayUntil ) {
         SQLiteDatabase db = (new EnvelopesOpenHelper(cntx))
                             .getWritableDatabase();
         db.beginTransaction();
         try {
-            depositeDelayed(db, envelope, cents, description, delayUntil);
+	        depositeDelayed(db, envelope, cents, description, repeat, delayUntil);
             db.setTransactionSuccessful();
             cntx.getContentResolver().notifyChange(URI, null);
         } finally {

--- a/src/com/notriddle/budget/PaycheckFragment.java
+++ b/src/com/notriddle/budget/PaycheckFragment.java
@@ -210,6 +210,7 @@ public class PaycheckFragment extends OkFragment
     @Override public void ok() {
         SparseArray<Long> deposites = mEnvelopes.getDeposites();
         String description = mDescription.getText().toString();
+        String frequency = null;
         int l = deposites.size();
         SQLiteDatabase db = (new EnvelopesOpenHelper(getActivity())).getWritableDatabase();
         db.beginTransaction();
@@ -218,7 +219,7 @@ public class PaycheckFragment extends OkFragment
             for (int i = 0; i != l; ++i) {
                 int id = deposites.keyAt(i);
                 long centsDeposited = deposites.valueAt(i);
-                EnvelopesOpenHelper.deposite(db, id, centsDeposited, description);
+                EnvelopesOpenHelper.deposite(db, id, centsDeposited, description, frequency);
                 values.put("lastPaycheckCents", centsDeposited);
                 db.update("envelopes", values, "_id = ?", new String[] {
                     Integer.toString(id)

--- a/src/com/notriddle/budget/TransferFragment.java
+++ b/src/com/notriddle/budget/TransferFragment.java
@@ -156,8 +156,8 @@ public class TransferFragment extends OkFragment
                             .getWritableDatabase();
         db.beginTransaction();
         try {
-            EnvelopesOpenHelper.deposite(db, fromId, -1*transferCents, description);
-            EnvelopesOpenHelper.deposite(db, toId, transferCents, description);
+	        EnvelopesOpenHelper.deposite(db, fromId, -1*transferCents, description, null);
+            EnvelopesOpenHelper.deposite(db, toId, transferCents, description, null);
             db.setTransactionSuccessful();
             getActivity()
             .getContentResolver().notifyChange(EnvelopesOpenHelper.URI, null);


### PR DESCRIPTION
The behaviour is that repeating spends are added and marked as repeating in the log.
Each time the log is played, any repeating transactions are repeated accordingly and added to the log (as normal transactions) leaving the last such transaction as a repeating transaction. This last transaction is always a delayed transaction which means that the projected envelope value will include one future payment of each recurring transaction.
By deleting the future transaction, the repeating transaction is deleted as only the future transaction is marked as repeating in the db.

NOTE: There is a known bug that the playlog function is only called on creating of activity, so for the next projected spend of a recurring payment to appear, the activity needs to be restarted.