### PR TITLE
bugfix

### DIFF
--- a/src/com/notriddle/budget/EnvelopeDetailsFragment.java
+++ b/src/com/notriddle/budget/EnvelopeDetailsFragment.java
@@ -185,7 +185,7 @@ public class EnvelopeDetailsFragment extends Fragment
         ab.setDisplayShowTitleEnabled(true);
         ab.setDisplayShowCustomEnabled(false);
         ab.setCustomView(null);
-        if (mName.getText().length() == 0 && mLogAdapter.getCount() == 0 && mEnvelopeData != null && mLogData != null) {
+        if (mName != null && mName.getText().length() == 0 && mLogAdapter != null && mLogAdapter.getCount() == 0 && mEnvelopeData != null && mLogData != null) {
             deleteThis();
             mDatabase.close();
             mDatabase = null;


### PR DESCRIPTION
Switching from portrait to landscape in Spend fragment with 'delayed' checked and then hitting back on the action bar causes the app to crash.